### PR TITLE
Fix/localization search

### DIFF
--- a/app/[locale]/components/headers.tsx
+++ b/app/[locale]/components/headers.tsx
@@ -7,6 +7,10 @@ interface TagHeaderProps {
   tag: string | string[];
 }
 
+interface QueryHeaderProps {
+  query: string;
+}
+
 export function TagHeader({ tag }: TagHeaderProps) {
   const t = useTranslations("HomePage");
   const gradient = useRandomGradient();
@@ -17,6 +21,21 @@ export function TagHeader({ tag }: TagHeaderProps) {
         <h1 className="text-center text-6xl text-slate-100 capitalize">
           {t("tagResult")}"
           {decodeURIComponent(Array.isArray(tag) ? tag.join(" ") : tag)}"
+        </h1>
+      </div>
+    </section>
+  );
+}
+
+export function SearchHeader({ query }: QueryHeaderProps) {
+  const t = useTranslations("HomePage");
+  const gradient = useRandomGradient();
+
+  return (
+    <section className="w-full h-48" style={{ backgroundImage: gradient }}>
+      <div className="py-14 text-white">
+        <h1 className="text-slate-100 capitalize text-5xl mb-9 text-center">
+          {t("searchResult")}"{query}"
         </h1>
       </div>
     </section>

--- a/app/[locale]/components/localization-dropdown.tsx
+++ b/app/[locale]/components/localization-dropdown.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 
 export default function LocalizationDropdown() {
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const router = useRouter();
 
   const currentLocale = pathname.split("/")[1] || "en";
@@ -34,7 +35,12 @@ export default function LocalizationDropdown() {
       newPath = `/${selectedLocale}${pathname}`;
     }
 
-    router.replace(newPath);
+    const searchParamsString = searchParams.toString();
+    const newUrl = searchParamsString
+      ? `${newPath}?${searchParamsString}`
+      : newPath;
+
+    router.replace(newUrl);
   }
 
   const t = useTranslations("HomePage");

--- a/app/[locale]/search/page.tsx
+++ b/app/[locale]/search/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
+import { useSearchParams, usePathname } from "next/navigation";
 import { PostPreview } from "../components/post-preview";
 import { useEffect, useState } from "react";
 import { getPostsBySearchResult } from "@/app/actions";
@@ -8,6 +8,7 @@ import { Post } from "@prisma/client";
 import { notFound } from "next/navigation";
 import { Navbar } from "@/app/[locale]/components/navbar";
 import { useTranslations } from "next-intl";
+import { SearchHeader } from "@/app/[locale]/components/headers";
 
 export default function SearchPage() {
   const searchParams = useSearchParams();
@@ -15,11 +16,14 @@ export default function SearchPage() {
   const [posts, setPosts] = useState<Post[]>([]);
   const [loading, setLoading] = useState(true);
 
+  const pathname = usePathname();
+  const locale = pathname.split("/")[1] as "en" | "es";
+
   useEffect(() => {
     const fetchData = async () => {
       setLoading(true);
       try {
-        const results = await getPostsBySearchResult(query, 0, 10, "en");
+        const results = await getPostsBySearchResult(query, 0, 10, locale);
         setPosts(results);
       } finally {
         setLoading(false);
@@ -27,7 +31,7 @@ export default function SearchPage() {
     };
 
     if (query) fetchData();
-  }, [query]);
+  }, [query, locale]);
 
   const t = useTranslations("HomePage");
 
@@ -38,22 +42,25 @@ export default function SearchPage() {
   return (
     <main>
       <Navbar />
-      <div className="py-11">
-        <h1 className="text-5xl mb-9 text-center">
-          {t("searchResult")}"{query}"
-        </h1>
+      <SearchHeader query={query} />
+      <div className="p-9">
         {loading ? (
-          <p className="text-center text-lg">Loading...</p>
+          <div className="flex flex-col items-center justify-center">
+            <div className="animate-spin rounded-full h-16 w-16 border-t-4 border-b-4 border-blue-500 mb-4"></div>
+            <p className="text-center text-lg text-blue-700 animate-pulse">
+              {t("loading")}...
+            </p>
+          </div>
         ) : posts.length > 0 ? (
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             {posts.map((post) => (
               <div key={post.slug} className="p-4">
                 <PostPreview
-                  title={post.title}
+                  title={post.titleTranslations[locale]}
                   coverImage={post.coverImage}
                   date={new Date(post.publishedAt)}
                   slug={post.slug}
-                  excerpt={post.excerpt}
+                  excerpt={post.excerptTranslations[locale] || "null"}
                 />
               </div>
             ))}

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -160,7 +160,7 @@ export async function getPostsBySearchResult(
   searchQuery: string,
   skip: number,
   take: number,
-  locale: "en" | "es" = "en"
+  locale: string
 ): Promise<Post[]> {
   const response = await fetch(
     `/api/search?query=${encodeURIComponent(

--- a/app/api/article/filter/route.ts
+++ b/app/api/article/filter/route.ts
@@ -73,6 +73,7 @@ export async function POST(req: NextRequest) {
             },
           });
         }
+        console.log(`Successfully processed article with URL: ${article.url}`);
       } catch (error) {
         console.error(
           `Error processing article with URL: ${article.url}`,

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -13,7 +13,7 @@ export async function GET(req: Request): Promise<Response> {
       .trim()
       .split(/\s+/)
       .map((term) => `${term}:*`)
-      .join(" & ");
+      .join(" | ");
 
     const tsQueryLanguage = locale === "es" ? "searchVectorEs" : "searchVector";
 
@@ -22,7 +22,7 @@ export async function GET(req: Request): Promise<Response> {
         SELECT "slug", "title", "coverImage", "excerpt", "publishedAt", "titleTranslations", "contentTranslations", "excerptTranslations"
         FROM "Post" 
         WHERE "${tsQueryLanguage}" @@ to_tsquery($1)
-        ORDER BY "publishedAt" DESC
+        ORDER BY ts_rank("${tsQueryLanguage}", to_tsquery($1)) DESC, "publishedAt" DESC
         LIMIT $2 OFFSET $3;
       `,
       searchQuery,

--- a/utils/openai.ts
+++ b/utils/openai.ts
@@ -149,7 +149,7 @@ export async function writePost(prompt: string) {
         },
         {
           role: "user",
-          content: `Translate the following tags into Spanish: ${blogTags}. Do not translate names, brands, or entities.`,
+          content: `Translate the following tags into Spanish: ${blogTags}. Do not translate names, brands, or entities. And just answer with the translation.`,
         },
       ],
       model: "gpt-4o-mini",


### PR DESCRIPTION
En actions.ts cambié el tipo del locale por un string para solucionar un error.

En headers.tsx creé el header para la página de search, similar a los otros.

En localization-dropdown.tsx incluí los searchParams a la hora de cambiar el locale para que al cambiar el locale en la página de search no se elimine el query de la url.

En la página de search hice que se obtuviera el locale para mostrar los resultados en el idioma del locale. También hice que la pantalla de Loading sea más visualmente atractiva.

En el endpoint de search hice que no sea necesario que contengan la búsqueda exacta para traer resultados, y que los resultados se muestren en orden de relevancia.

En el util de openai cambié un poquito la prompt para obtener mejores resultados.