### PR TITLE
Fix/footer

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -62,10 +62,15 @@ export default function RootLayout({
         <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
       </head>
       <body
-        className={cn(inter.className, "dark:bg-slate-900 dark:text-slate-400")}
+        className={cn(
+          inter.className,
+          "dark:bg-slate-900 dark:text-slate-400 flex flex-col min-h-screen"
+        )}
       >
         <ThemeSwitcher />
-        <MessagesRequest>{children}</MessagesRequest>
+        <div className="flex-grow">
+          <MessagesRequest>{children}</MessagesRequest>
+        </div>
         <Footer />
       </body>
     </html>

--- a/app/api/tags/tags/route.ts
+++ b/app/api/tags/tags/route.ts
@@ -14,8 +14,8 @@ export async function GET(req: Request): Promise<Response> {
         },
       },
       select: {
-        nameEs: locale === "es",
-        nameEn: locale === "en",
+        nameEs: true,
+        nameEn: true,
         _count: {
           select: {
             posts: true,
@@ -26,6 +26,10 @@ export async function GET(req: Request): Promise<Response> {
 
     const formattedTags = tags.map((tag) => ({
       name: locale === "es" ? tag.nameEs : tag.nameEn,
+      translations: {
+        en: tag.nameEn,
+        es: tag.nameEs,
+      },
       postCount: tag._count.posts,
     }));
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -31,6 +31,7 @@
     "editorEmail": "emiliodavidcabezascc@gmail.com",
     "contactNotice": "Please note that due to the extreme volume of emails we receive (hundreds and hundreds a day, most with requests to listen to new records) we can’t reply to everything. Cheers!",
     "searchResult": "Search results for: ",
-    "tagResult": "Showing posts with tag: "
+    "tagResult": "Showing posts with tag: ",
+    "noResults": "No results found"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -31,6 +31,7 @@
     "editorEmail": "emiliodavidcabezascc@gmail.com",
     "contactNotice": "Tenga en cuenta que, debido al enorme volumen de correos electrónicos que recibimos (cientos cada día, la mayoría con solicitudes para escuchar nuevos discos), no podemos responder a todos – hacerlo sería un trabajo de tiempo completo y no tendríamos tiempo para escribir sobre la música que amamos. ¡Saludos!",
     "searchResult": "Resultados de busqueda para: ",
-    "tagResult": "Mostrando posts con el tag: "
+    "tagResult": "Mostrando posts con el tag: ",
+    "noResults": "No se encontraron resultados"
   }
 }


### PR DESCRIPTION
En layout utilicé tailwind para volver el footer en un sticky footer y que se mantenga en el fondo de la pantalla en todo momento, incluso cuando no hay contenido en la pantalla, pero que al mismo tiempo funcione de como un footer normal.

En el localization dropdown hice que cuando se cambia el locale verifique que esté en una página de posts por tag, y cuando se cambia el locale cambie la url para que contenga la traducción de dicho tag, y así pueda recibir los posts correspondientes pero en el local configurado. Este solo trae la traducción de dicho tag de entre la lista de todos los tags traídos del endpoint, y si es una página de tags, reemplaza el actual tag por su traducción correspondiente. Si no es una página de tags, funciona con normalidad.

En el endpoint de los tags hice que la consulta trajera todas las traducciones del tag, en vez de solo la del locale actual.