### PR TITLE
Feat/add server componets 2

### DIFF
--- a/app/[locale]/about/page.tsx
+++ b/app/[locale]/about/page.tsx
@@ -1,7 +1,9 @@
 import Container from "@/app/[locale]/components/container";
 import Navbar from "@/app/[locale]/components/navbar";
-import { AboutHeader } from "@/app/[locale]/components/headers";
+import { AboutHeaderWrapper } from "@/app/[locale]/components/headers-wrappers";
 import AboutContent from "@/app/[locale]/components/about-content";
+import { Suspense } from "react";
+import Skeleton from "@/app/[locale]/components/skeleton";
 
 type Locale = "en" | "es";
 
@@ -14,10 +16,16 @@ interface Props {
 export default async function NewsPage({ params: { locale } }: Props) {
   return (
     <main>
-      <Navbar locale={locale} />
-      <AboutHeader />
+      <Suspense fallback={<Skeleton className="h-24 w-full rounded-md" />}>
+        <Navbar locale={locale} />
+      </Suspense>
+      <Suspense fallback={<Skeleton className="h-24 w-full rounded-md" />}>
+        <AboutHeaderWrapper />
+      </Suspense>
       <Container>
-        <AboutContent />
+        <Suspense fallback={<Skeleton className="h-24 w-full rounded-md" />}>
+          <AboutContent />
+        </Suspense>
       </Container>
     </main>
   );

--- a/app/[locale]/components/contact-content.tsx
+++ b/app/[locale]/components/contact-content.tsx
@@ -1,6 +1,6 @@
 import { useTranslations } from "next-intl";
 
-export default function ContactHeader() {
+export default function ContactContentHeader() {
   const t = useTranslations("HomePage");
   return (
     <div className="py-16 px-32">

--- a/app/[locale]/components/headers-wrappers.tsx
+++ b/app/[locale]/components/headers-wrappers.tsx
@@ -1,0 +1,21 @@
+import {
+  TagHeader,
+  AboutHeader,
+  ContactHeader,
+} from "@/app/[locale]/components/headers";
+
+interface TagHeaderWrapperProps {
+  tag: string | string[];
+}
+
+export function TagHeaderWrapper({ tag }: TagHeaderWrapperProps) {
+  return <TagHeader tag={tag} />;
+}
+
+export function AboutHeaderWrapper() {
+  return <AboutHeader />;
+}
+
+export function ContactHeaderWrapper() {
+  return <ContactHeader />;
+}

--- a/app/[locale]/components/navbar-buttons.tsx
+++ b/app/[locale]/components/navbar-buttons.tsx
@@ -3,7 +3,7 @@
 import { Link } from "@/i18n/routing";
 import { useTranslations } from "next-intl";
 import { usePathname } from "next/navigation";
-import { Locale } from "./posts-logic";
+import { Locale } from "@/app/[locale]/components/posts-logic";
 
 type Tag = {
   name: string;

--- a/app/[locale]/components/posts-search-display.tsx
+++ b/app/[locale]/components/posts-search-display.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Post } from "@prisma/client";
+import { PostPreview } from "@/app/[locale]/components/post-preview";
+import { useTranslations } from "next-intl";
+import { notFound } from "next/navigation";
+import { fetchPostsBySearchResult } from "@/app/lib/fetches";
+import { Locale } from "@/app/[locale]/components/posts-logic";
+
+interface PostsSearchDisplayProps {
+  locale: Locale;
+  query: string;
+}
+
+export default function PostsSearchDisplay({
+  locale,
+  query,
+}: PostsSearchDisplayProps) {
+  const [loading, setLoading] = useState(true);
+  const [posts, setPosts] = useState<Post[]>([]);
+
+  const t = useTranslations("HomePage");
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      try {
+        const results = await fetchPostsBySearchResult(query, 0, 10, locale);
+        setPosts(results);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (query) fetchData();
+  }, [query, locale]);
+
+  if (!posts && !loading) {
+    return notFound();
+  }
+
+  return (
+    <div className="p-9">
+      {loading ? (
+        <div className="flex flex-col items-center justify-center">
+          <div className="animate-spin rounded-full h-16 w-16 border-t-4 border-b-4 border-blue-500 mb-4"></div>
+          <p className="text-center text-lg text-blue-700 animate-pulse">
+            {t("loading")}...
+          </p>
+        </div>
+      ) : posts.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {posts.map((post) => (
+            <div key={post.slug} className="p-4">
+              <PostPreview
+                title={post.titleTranslations[locale]}
+                coverImage={post.coverImage}
+                date={new Date(post.publishedAt)}
+                slug={post.slug}
+                excerpt={post.excerptTranslations[locale] || "null"}
+              />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-center text-lg">No results found</p>
+      )}
+    </div>
+  );
+}

--- a/app/[locale]/components/search-elements-wrapper.tsx
+++ b/app/[locale]/components/search-elements-wrapper.tsx
@@ -1,0 +1,5 @@
+import SearchElements from "@/app/[locale]/components/search-elements";
+
+export default function SearchElementsWrapper() {
+  return <SearchElements />;
+}

--- a/app/[locale]/components/search-elements.tsx
+++ b/app/[locale]/components/search-elements.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { SearchHeader } from "@/app/[locale]/components/headers";
+import PostsSearchDisplay from "@/app/[locale]/components/posts-search-display";
+import { useSearchParams } from "next/navigation";
+import Navbar from "@/app/[locale]/components/navbar";
+import { usePathname } from "next/navigation";
+
+export default function SearchElements() {
+  const pathname = usePathname();
+  const locale = pathname.split("/")[1] as "en" | "es";
+  const searchParams = useSearchParams();
+  const query = searchParams.get("query") || "";
+  return (
+    <main>
+      <Navbar locale={locale} />
+      <SearchHeader query={query} />
+      <PostsSearchDisplay locale={locale} query={query} />
+    </main>
+  );
+}

--- a/app/[locale]/components/show-more-logic.tsx
+++ b/app/[locale]/components/show-more-logic.tsx
@@ -4,7 +4,7 @@ import React, { useState } from "react";
 import { Post } from "@prisma/client";
 import { fetchMorePosts } from "@/app/lib/fetches";
 import { useTranslations } from "next-intl";
-import PostDisplayed from "./posts-displayed";
+import PostDisplayed from "@/app/[locale]/components/posts-displayed";
 
 type ShowMoreButtonProps = {
   initialPosts: Post[];

--- a/app/[locale]/components/tag-page-content-wrapper.tsx
+++ b/app/[locale]/components/tag-page-content-wrapper.tsx
@@ -1,0 +1,5 @@
+import TagPageContent from "@/app/[locale]/components/tag-page-content";
+
+export default function TagPageContentWrapper() {
+  return <TagPageContent />;
+}

--- a/app/[locale]/components/tag-page-content.tsx
+++ b/app/[locale]/components/tag-page-content.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import Navbar from "@/app/[locale]/components/navbar";
+import { TagHeader } from "@/app/[locale]/components/headers";
+import { useParams, notFound } from "next/navigation";
+import { Locale } from "@/app/[locale]/components/posts-logic";
+import TagPostsDisplay from "@/app/[locale]/components/tag-posts-display";
+import { useState, useEffect } from "react";
+
+type Params = {
+  tag: string | string[];
+  locale: Locale;
+};
+
+type Post = {
+  id: number;
+  title: string;
+  excerpt: string;
+  slug: string;
+  coverImage: string;
+  publishedAt: string;
+};
+
+export default function TagPageContent() {
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const { tag, locale } = useParams<Params>();
+
+  useEffect(() => {
+    if (tag && locale) {
+      const fetchPosts = async () => {
+        setLoading(true);
+        try {
+          const res = await fetch(
+            `/api/tags/posts-by-tag/${tag}?locale=${locale}`
+          );
+          const data = await res.json();
+          setPosts(data);
+        } finally {
+          setLoading(false);
+        }
+      };
+      fetchPosts();
+    }
+  }, [tag, locale]);
+
+  if (!posts && !loading) {
+    return notFound();
+  }
+
+  return (
+    <main>
+      <Navbar locale={locale} />
+      <TagHeader tag={tag} />
+      <TagPostsDisplay posts={posts} loading={loading} />
+    </main>
+  );
+}

--- a/app/[locale]/components/tag-posts-display.tsx
+++ b/app/[locale]/components/tag-posts-display.tsx
@@ -1,0 +1,46 @@
+import { PostPreview } from "@/app/[locale]/components/post-preview";
+import { useTranslations } from "next-intl";
+
+type Post = {
+  id: number;
+  title: string;
+  excerpt: string;
+  slug: string;
+  coverImage: string;
+  publishedAt: string;
+};
+
+interface TagPostsDisplayProps {
+  posts: Post[];
+  loading: boolean;
+}
+
+export default function TagPostsDisplay({
+  posts,
+  loading,
+}: TagPostsDisplayProps) {
+  const t = useTranslations("HomePage");
+  return (
+    <div className="p-12">
+      {loading ? (
+        <p className="text-center text-lg">{t("loading")}</p>
+      ) : posts.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {posts.map((post) => (
+            <div key={post.id} className="p-4">
+              <PostPreview
+                title={post.title}
+                coverImage={post.coverImage}
+                date={new Date(post.publishedAt)}
+                slug={post.slug}
+                excerpt={post.excerpt}
+              />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-center text-lg">{t("noResults")}</p>
+      )}
+    </div>
+  );
+}

--- a/app/[locale]/contact/page.tsx
+++ b/app/[locale]/contact/page.tsx
@@ -1,7 +1,9 @@
 import Container from "@/app/[locale]/components/container";
 import Navbar from "@/app/[locale]/components/navbar";
-import { ContactHeader } from "@/app/[locale]/components/headers";
 import ContactContent from "@/app/[locale]/components/contact-content";
+import { Suspense } from "react";
+import Skeleton from "@/app/[locale]/components/skeleton";
+import { ContactHeaderWrapper } from "@/app/[locale]/components/headers-wrappers";
 
 type Locale = "en" | "es";
 
@@ -14,10 +16,16 @@ interface Props {
 export default async function NewsPage({ params: { locale } }: Props) {
   return (
     <main>
-      <Navbar locale={locale} />
-      <ContactHeader />
+      <Suspense fallback={<Skeleton className="h-24 w-full rounded-md" />}>
+        <Navbar locale={locale} />
+      </Suspense>
+      <Suspense fallback={<Skeleton className="h-24 w-full rounded-md" />}>
+        <ContactHeaderWrapper />
+      </Suspense>
       <Container>
-        <ContactContent />
+        <Suspense fallback={<Skeleton className="h-24 w-full rounded-md" />}>
+          <ContactContent />
+        </Suspense>
       </Container>
     </main>
   );

--- a/app/[locale]/posts/[slug]/components/post-body.tsx
+++ b/app/[locale]/posts/[slug]/components/post-body.tsx
@@ -1,4 +1,4 @@
-import markdownStyles from "./markdown-styles.module.css";
+import markdownStyles from "@/app/[locale]/posts/[slug]/components/markdown-styles.module.css";
 
 type Props = {
   content: string;

--- a/app/[locale]/posts/[slug]/page.tsx
+++ b/app/[locale]/posts/[slug]/page.tsx
@@ -2,10 +2,13 @@ import { getPostBySlug } from "@/app/lib/queries";
 import { notFound } from "next/navigation";
 import Image from "next/image";
 import Navbar from "@/app/[locale]/components/navbar";
+import { Suspense } from "react";
+import Skeleton from "@/app/[locale]/components/skeleton";
+import { Locale } from "@/app/[locale]/components/posts-logic";
 
 type Props = {
   params: {
-    locale: "en" | "es";
+    locale: Locale;
     slug: string;
   };
 };
@@ -19,7 +22,9 @@ export default async function PostPage({ params: { locale, slug } }: Props) {
 
   return (
     <main>
-      <Navbar locale={locale} />
+      <Suspense fallback={<Skeleton className="h-24 w-full rounded-md" />}>
+        <Navbar locale={locale} />
+      </Suspense>
       <div className="max-w-3xl mx-auto px-4 py-10">
         <h1
           className="text-4xl font-bold text-gray-800 mb-6"

--- a/app/[locale]/search/page.tsx
+++ b/app/[locale]/search/page.tsx
@@ -1,74 +1,13 @@
-"use client";
-
-import { useSearchParams, usePathname } from "next/navigation";
-import { PostPreview } from "@/app/[locale]/components/post-preview";
-import { useEffect, useState } from "react";
-import { fetchPostsBySearchResult } from "@/app/lib/fetches";
-import { Post } from "@prisma/client";
-import { notFound } from "next/navigation";
-import { useTranslations } from "next-intl";
-import { SearchHeader } from "@/app/[locale]/components/headers";
-import Navbar from "@/app/[locale]/components/navbar";
+import SearchElementsWrapper from "@/app/[locale]/components/search-elements-wrapper";
+import { Suspense } from "react";
+import Skeleton from "@/app/[locale]/components/skeleton";
 
 export default function SearchPage() {
-  const searchParams = useSearchParams();
-  const query = searchParams.get("query") || "";
-  const [posts, setPosts] = useState<Post[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  const pathname = usePathname();
-  const locale = pathname.split("/")[1] as "en" | "es";
-
-  useEffect(() => {
-    const fetchData = async () => {
-      setLoading(true);
-      try {
-        const results = await fetchPostsBySearchResult(query, 0, 10, locale);
-        setPosts(results);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    if (query) fetchData();
-  }, [query, locale]);
-
-  const t = useTranslations("HomePage");
-
-  if (!posts && !loading) {
-    return notFound();
-  }
-
   return (
     <main>
-      <Navbar locale={locale} />
-      <SearchHeader query={query} />
-      <div className="p-9">
-        {loading ? (
-          <div className="flex flex-col items-center justify-center">
-            <div className="animate-spin rounded-full h-16 w-16 border-t-4 border-b-4 border-blue-500 mb-4"></div>
-            <p className="text-center text-lg text-blue-700 animate-pulse">
-              {t("loading")}...
-            </p>
-          </div>
-        ) : posts.length > 0 ? (
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            {posts.map((post) => (
-              <div key={post.slug} className="p-4">
-                <PostPreview
-                  title={post.titleTranslations[locale]}
-                  coverImage={post.coverImage}
-                  date={new Date(post.publishedAt)}
-                  slug={post.slug}
-                  excerpt={post.excerptTranslations[locale] || "null"}
-                />
-              </div>
-            ))}
-          </div>
-        ) : (
-          <p className="text-center text-lg">No results found</p>
-        )}
-      </div>
+      <Suspense fallback={<Skeleton className="h-24 w-full rounded-md" />}>
+        <SearchElementsWrapper />
+      </Suspense>
     </main>
   );
 }

--- a/app/[locale]/tag/[tag]/page.tsx
+++ b/app/[locale]/tag/[tag]/page.tsx
@@ -1,80 +1,13 @@
-"use client";
-
-import { useEffect, useState } from "react";
-import { notFound, useParams, usePathname } from "next/navigation";
-import Navbar from "@/app/[locale]/components/navbar";
-import { useTranslations } from "next-intl";
-import { PostPreview } from "@/app/[locale]/components/post-preview";
-import { TagHeader } from "@/app/[locale]/components/headers";
-
-type Params = {
-  tag: string | string[];
-  locale: "en" | "es";
-};
-
-type Post = {
-  id: number;
-  title: string;
-  excerpt: string;
-  slug: string;
-  coverImage: string;
-  publishedAt: string;
-};
+import { Suspense } from "react";
+import Skeleton from "@/app/[locale]/components/skeleton";
+import TagPageContentWrapper from "@/app/[locale]/components/tag-page-content-wrapper";
 
 export default function TagPage() {
-  const { tag, locale } = useParams<Params>();
-  const [posts, setPosts] = useState<Post[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    if (tag && locale) {
-      const fetchPosts = async () => {
-        setLoading(true);
-        try {
-          const res = await fetch(
-            `/api/tags/posts-by-tag/${tag}?locale=${locale}`
-          );
-          const data = await res.json();
-          setPosts(data);
-        } finally {
-          setLoading(false);
-        }
-      };
-      fetchPosts();
-    }
-  }, [tag, locale]);
-
-  const t = useTranslations("HomePage");
-
-  if (!posts && !loading) {
-    return notFound();
-  }
-
   return (
     <main>
-      <Navbar locale={locale} />
-      <TagHeader tag={tag} />
-      <div className="p-12">
-        {loading ? (
-          <p className="text-center text-lg">{t("loading")}</p>
-        ) : posts.length > 0 ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {posts.map((post) => (
-              <div key={post.id} className="p-4">
-                <PostPreview
-                  title={post.title}
-                  coverImage={post.coverImage}
-                  date={new Date(post.publishedAt)}
-                  slug={post.slug}
-                  excerpt={post.excerpt}
-                />
-              </div>
-            ))}
-          </div>
-        ) : (
-          <p className="text-center text-lg">{t("noResults")}</p>
-        )}
-      </div>
+      <Suspense fallback={<Skeleton className="h-24 w-full rounded-md" />}>
+        <TagPageContentWrapper />
+      </Suspense>
     </main>
   );
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -22,7 +22,7 @@
     "contactSubheader": "Si necesitas una palabra de nosotros",
     "editorName": "Editor (Artículos): Emilio Cabezas",
     "editorEmail": "emiliodavidcabezascc@gmail.com",
-    "contactNotice": "Tenga en cuenta que, debido al enorme volumen de correos electrónicos que recibimos (cientos cada día, la mayoría con solicitudes para escuchar nuevos discos), no podemos responder a todos – hacerlo sería un trabajo de tiempo completo y no tendríamos tiempo para escribir sobre la música que amamos. ¡Saludos!",
+    "contactNotice": "Tenga en cuenta que, debido al enorme volumen de correos electrónicos que recibimos (cientos cada día, la mayoría con solicitudes para escuchar nuevos discos), no podemos responder a todos. ¡Saludos!",
     "searchResult": "Resultados de busqueda para: ",
     "tagResult": "Mostrando posts con el tag: ",
     "noResults": "No se encontraron resultados"


### PR DESCRIPTION
En la página de about agregué los suspense.

En la página de contact-content le cambié el nombre a la función para evitar confusiones.

Hice una página para wrappers de los headers, para que se rendericen como server components y mantener la estructura de server->server->client.

Hice un componente aparte para mostrar los posts que se muestran al momento de la búsqueda.

También hice un wrapper para los elementos de la página de búsqueda.

También hice una página cliente para mostrar los elementos de la página de búsqueda y pasarle los props que se traen por medio de hooks.

También hice un wrapper para el contenido de la página de tags.

Y un componente cliente para los componentes de la página de tags.

También hice un componente aparte para mostrar los posts en la página de tags.

Añadí los suspense a la página de contacto.

Añadí los suspense a la página de un determinado post.

Añadí los suspense a la página de búsqueda.

Añadí los suspense a la página de tags.